### PR TITLE
A6, A7: Add undeclared variables, remove a test

### DIFF
--- a/assignment6/abekarplus-10.imp
+++ b/assignment6/abekarplus-10.imp
@@ -1,5 +1,0 @@
-decl alloc5, Alloc7, ref in
-	alloc5 := new 1;
-	Alloc7 := new 1;
-	ref := new 1;
-

--- a/assignment6/abekarplus-10.solution
+++ b/assignment6/abekarplus-10.solution
@@ -1,6 +1,0 @@
-Alloc7 : {alloc7}
-alloc5 : {alloc5}
-ref : {alloc9}
-Alloc5 : {}
-Alloc7 : {}
-Alloc9 : {}

--- a/assignment6/skylerbistarkeyrez-3.imp
+++ b/assignment6/skylerbistarkeyrez-3.imp
@@ -1,4 +1,4 @@
-decl x in
+decl x, y in
 x := new 2;
 x.1 := new 1;
 y := x.1;

--- a/assignment6/skylerbistarkeyrez-3.solution
+++ b/assignment6/skylerbistarkeyrez-3.solution
@@ -1,4 +1,4 @@
-x : {alloc3}
-y : {alloc5}
-Alloc3 : {alloc5}
-Alloc5 : {}
+x : {alloc4}
+y : {alloc6}
+Alloc4 : {alloc6}
+Alloc6 : {}

--- a/assignment6/skylerbistarkeyrez-4.imp
+++ b/assignment6/skylerbistarkeyrez-4.imp
@@ -1,4 +1,4 @@
-decl x in
+decl x, y in
 x := new 2;
 x.1 := new 1;
 y := x.1;

--- a/assignment6/skylerbistarkeyrez-4.solution
+++ b/assignment6/skylerbistarkeyrez-4.solution
@@ -1,5 +1,5 @@
-x : {alloc3}
-y : {alloc5}
-Alloc10 : {}
-Alloc3 : {alloc5}
-Alloc5 : {alloc10}
+x : {alloc4}
+y : {alloc6}
+Alloc11 : {}
+Alloc4 : {alloc6}
+Alloc6 : {alloc11}

--- a/assignment7/abekarplus-10.imp
+++ b/assignment7/abekarplus-10.imp
@@ -1,5 +1,0 @@
-decl alloc5, Alloc7, ref in
-	alloc5 := new 1;
-	Alloc7 := new 1;
-	ref := new 1;
-

--- a/assignment7/abekarplus-10.solution
+++ b/assignment7/abekarplus-10.solution
@@ -1,6 +1,0 @@
-Alloc5
-Alloc7
-Alloc7
-Alloc9
-alloc5
-ref

--- a/assignment7/skylerbistarkeyrez-3.imp
+++ b/assignment7/skylerbistarkeyrez-3.imp
@@ -1,4 +1,4 @@
-decl x in
+decl x, y in
 x := new 2;
 x.1 := new 1;
 y := x.1;

--- a/assignment7/skylerbistarkeyrez-3.solution
+++ b/assignment7/skylerbistarkeyrez-3.solution
@@ -1,3 +1,3 @@
-Alloc3, y
-Alloc5
+Alloc4, y
+Alloc6
 x

--- a/assignment7/skylerbistarkeyrez-4.imp
+++ b/assignment7/skylerbistarkeyrez-4.imp
@@ -1,4 +1,4 @@
-decl x in
+decl x, y in
 x := new 2;
 x.1 := new 1;
 y := x.1;

--- a/assignment7/skylerbistarkeyrez-4.solution
+++ b/assignment7/skylerbistarkeyrez-4.solution
@@ -1,4 +1,4 @@
-Alloc10
-Alloc3, y
-Alloc5
+Alloc11
+Alloc4, y
+Alloc6
 x


### PR DESCRIPTION
* Removed abekarplus-10 from A6 and A7 (see #16)
* Added `y` to the variable declarations in skylerbistarkeyrez-3,4 in A6 and A7 (it was being used without being declared)